### PR TITLE
feature: add skipping keys that are not present in the template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bpac-js",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bpac-js",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.28.1",

--- a/src/BrotherSdk.ts
+++ b/src/BrotherSdk.ts
@@ -181,6 +181,7 @@ export default class BrotherSdk {
             copies = 1,
             printName = "BPAC-Document",
             fitPage = false,
+            skipNoPresentKeys = false,
             ...opts
         } = config || {};
 
@@ -194,7 +195,7 @@ export default class BrotherSdk {
         await setPrinter(this.printer, fitPage);
 
         for (const item of dataArray) {
-            await populateObjectsInTemplate(item);
+            await populateObjectsInTemplate(item, { skipNoPresentKeys });
             await startPrint(printName, bitwiseOpts);
             await printOut(copies);
         }

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,5 +1,5 @@
 import * as bpac from "./vendor/bpac-v3.4.js";
-import { TemplateData, ObjectTypes, PrinterStatus, ExportType } from "./types.ts";
+import { TemplateData, ObjectTypes, PrinterStatus, ExportType, PrintConfig } from "./types.ts";
 
 const Doc = bpac.IDocument;
 
@@ -298,7 +298,9 @@ export const exportDocument = async (type: ExportType, filePath: string, dpi: nu
 };
 
 // Optimized 03/15/25
-export const populateObjectsInTemplate = async (data: TemplateData): Promise<void> => {
+export const populateObjectsInTemplate = async (data: TemplateData, options?: Pick<PrintConfig, "skipNoPresentKeys">): Promise<void> => {
+    const { skipNoPresentKeys = false } = options || {};
+
     for (const key of Object.keys(data)) {
         const value = data[key];
 
@@ -306,8 +308,11 @@ export const populateObjectsInTemplate = async (data: TemplateData): Promise<voi
             const obj = await Doc.GetObject(key);
 
             if (!obj) {
-                await closeTemplate();
-                throw new Error(`Object "${key}" not found in the template.`);
+                if (!skipNoPresentKeys) {
+                    await closeTemplate();
+                    throw new Error(`Object "${key}" not found in the template.`);
+                }
+                continue;
             }
 
             const type: number = await obj.Type;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,11 @@ export type Constructor = {
 export type PrintOptions = {
     copies?: number;
     printName?: string;
+    /**
+     * If true, the print will not fail if a key is not present in the template.
+     * @default false
+     */
+    skipNoPresentKeys?: boolean;
 };
 
 export enum PrintOptionFlag {


### PR DESCRIPTION
issue #20 

This contribution adds an additional option to print function that tells the populateObjectsInTemplate function how to behave when it detects a key that is not present in the template. FIY i didn't had an a good idea on how this option should be called so i just went with the first name that came to my mind