### PR TITLE
Ensure the SDK is initialised before we call getPrinterList()

### DIFF
--- a/src/BrotherSdk.ts
+++ b/src/BrotherSdk.ts
@@ -372,6 +372,7 @@ export default class BrotherSDK {
      *
      */
     static async getPrinterList(): Promise<string[]> {
+        BrotherSDK.#initialize();
         await BrotherSDK.printerIsReady();
         const printers = await getPrinters();
         return printers;


### PR DESCRIPTION
Because getPrinterList() is static the SDK doesn't get initialised which means the call to printerIsReady() always fails with a "Cannot establish printer communication" error

This fix just ensures the SDK is initialised