### PR TITLE
Use the specified printer in getPrinterStatus() instead of the one in the template

### DIFF
--- a/src/BrotherSdk.ts
+++ b/src/BrotherSdk.ts
@@ -83,6 +83,7 @@ export default class BrotherSDK {
     async getPrinterStatus(): Promise<PrinterStatus> {
         await BrotherSDK.printerIsReady();
         await openTemplate(this.templatePath);
+        if (this.printer) await setPrinter(this.printer, false);
         const statusObject = await printerStatus();
         await closeTemplate();
         return statusObject;


### PR DESCRIPTION
We don't set the printer after loading the template, so it defaults to the one that is hardcoded into the template itself.

This fix just sets the printer if we've specified a custom one, otherwise we just fall back to the printer in the template anyway.