### PR TITLE
fix: restore barcode text population for QR code objects

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -274,8 +274,7 @@ export const populateObjectsInTemplate = async (data: TemplateData, ignoreMissin
                 await obj.SetData(0, value, null);
                 break;
             case ObjectTypes.Barcode:
-                const barcodeIndex = await Doc.GetBarcodeIndex(key);
-                await Doc.SetBarcodeData(barcodeIndex, value);
+                obj.Text = value;
                 break;
             case ObjectTypes.ClipArt:
                 await obj.SetData(0, value, 0);


### PR DESCRIPTION
## Problem

In v3.0.0, QR code (barcode) objects in templates are not being populated with the provided data. Instead, the default value hardcoded in the `.lbx` template file is printed/previewed.

This is a regression from v2.2.0, which had the changelog entry: *"Patched a bug where QR codes were not being populated"*.

## Root Cause

In v2.2.0, `populateObjectsInTemplate` handled barcode objects with both `obj.Text = value` and `Doc.SetBarcodeData()`:

```typescript
// v2.2.0 (working)
case ObjectTypes.Barcode:
    const barcodeIndex = await Doc.GetBarcodeIndex(key);
    obj.Text = value;                              // ← sets the barcode data
    await Doc.SetBarcodeData(barcodeIndex, value);
    break;
```

During the v3.0.0 refactor, `obj.Text = value` was removed:

```typescript
// v3.0.0 (broken)
case ObjectTypes.Barcode:
    const barcodeIndex = await Doc.GetBarcodeIndex(key);
    await Doc.SetBarcodeData(barcodeIndex, value); // ← only method left
    break;
```

The problem is that `Doc.GetBarcodeIndex(key)` returns `undefined` for QR code objects. This causes `Doc.SetBarcodeData(undefined, value)` to silently do nothing — no error is thrown, but the barcode data is never updated.

## Fix

Replace the broken `GetBarcodeIndex` + `SetBarcodeData` approach with `obj.Text = value`, which correctly sets data for all barcode types including QR codes via `IObject::SetText`. This matches the working behavior from v2.2.0.

```typescript
case ObjectTypes.Barcode:
    obj.Text = value;
    break;
```

## Testing

Verified with Brother PT-P900W using `.lbx` templates containing QR code objects:
- QR code data is now correctly populated in both preview (`getImageData`) and print (`print`)
- Text, Image, and other object types continue to work as expected